### PR TITLE
rename attribute size to _size to avoid conflict

### DIFF
--- a/pymysqlpool.py
+++ b/pymysqlpool.py
@@ -100,11 +100,11 @@ class ConnectionPool:
 
     def __init__(self, size=5, name=None, *args, **kwargs):
         self._pool = queue.Queue(self._HARD_LIMIT)
-        self.size = size if 0 < size < self._HARD_LIMIT else self._HARD_LIMIT
+        self._size = size if 0 < size < self._HARD_LIMIT else self._HARD_LIMIT
         self.name = name if name else '-'.join(
             [kwargs.get('host', 'localhost'), str(kwargs.get('port', 3306)),
              kwargs.get('user', ''), kwargs.get('database', '')])
-        for _ in range(self.size):
+        for _ in range(self._size):
             conn = Connection(*args, **kwargs)
             conn._pool = self
             self._pool.put(conn)


### PR DESCRIPTION
As I was playing with this lib, I found that class `ConnectionPool` have conflict in terms of attribute and method naming, ie. `size`.

<img width="553" alt="Screen Shot 2019-09-30 at 14 06 22" src="https://user-images.githubusercontent.com/1107336/65856573-38d63600-e38c-11e9-8809-f13f87b4b19d.png">

This should solve them while maintaining the function names.