### PR TITLE
avoid adding log handler to root logger

### DIFF
--- a/pymysqlpool.py
+++ b/pymysqlpool.py
@@ -12,9 +12,20 @@ __all__ = ['Connection', 'ConnectionPool', 'logger']
 
 warnings.filterwarnings('error', category=pymysql.err.Warning)
 # use logging module for easy debug
-logging.basicConfig(format='%(asctime)s %(levelname)8s: %(message)s', datefmt='%m-%d %H:%M:%S')
-logger = logging.getLogger(__name__)
-logger.setLevel('WARNING')
+def _init_logger():
+    logger = logging.getLogger(__name__)
+    handler = logging.StreamHandler()
+    handler.setFomatter(
+        logging.Formatter(
+            fmt='%(asctime)s %(levelname)8s: %(message)s',
+            datefmt='%m-%d %H:%M:%S',
+        )
+    )
+    logger.addHandler(handler)
+    logger.setLevel('WARNING')
+
+
+logger = _init_logger()
 
 
 class Connection(pymysql.connections.Connection):


### PR DESCRIPTION
The current implementation calls `logging.basicConfig`, which will create a handler to root logger. In this approach, other loggers will print to stderr after importing this library because of the handler in the root logger.

In this code change, instead of calling `logging.basicConfig`, we create the handler with the same arguments and add it to the module logger. (resolves #16)